### PR TITLE
Add support of env param `NODE_PPCE_ENV` to determine which path will be cleaned

### DIFF
--- a/index.js
+++ b/index.js
@@ -171,10 +171,21 @@ module.exports = bundler => {
     pkgFile = require(path.resolve(root, 'package.json'))
   }catch(e){}
 
+  const ppce = process.env.NODE_PPCE_ENV || "";
   const paths = pkgFile["parcelCleanPaths"] || [];
   const unsafe = pkgFile["parcelCleanUnsafePaths"] || false;
 
-  let cleaner = new CleanPlugin(paths, {
+  let activePaths = [];
+
+  if (paths[ppce] || paths[ppce] == "") {
+    activePaths = paths[ppce];
+  }
+
+  else if (Array.isArray (paths) || typeof paths != 'object') {
+    activePaths = paths;
+  }
+
+  let cleaner = new CleanPlugin(activePaths, {
     root: root,
     unsafe: unsafe
   });


### PR DESCRIPTION
As what issue #3 and #4 needed, now it could be solved as below:

```bash
NODE_PPCE_ENV=build parcel build
```

```
// package.json
{
  "parcelCleanPaths": {
    "build": [
      "dist",         // removes 'dist' folder
      "build/*.*",    // removes all files in 'build' folder
      "web/*.js"      // removes all JavaScript files in 'web' folder
    ]
  }
}
```